### PR TITLE
games-util/pokerstove: remove test use flag

### DIFF
--- a/games-util/pokerstove/pokerstove-1.0.ebuild
+++ b/games-util/pokerstove/pokerstove-1.0.ebuild
@@ -19,8 +19,6 @@ fi
 
 LICENSE="BSD"
 SLOT="0"
-IUSE="test"
-RESTRICT="!test? ( test )"
 
 DEPEND="
 	dev-libs/boost

--- a/games-util/pokerstove/pokerstove-9999.ebuild
+++ b/games-util/pokerstove/pokerstove-9999.ebuild
@@ -19,8 +19,6 @@ fi
 
 LICENSE="BSD"
 SLOT="0"
-IUSE="test"
-RESTRICT="!test? ( test )"
 
 DEPEND="
 	dev-libs/boost


### PR DESCRIPTION
* Remove test use flag and its FEATURE restriction

Currently, games-util/pokerstove uses a test use flag which is not
needed because no extra packages or steps are needed for testing.
Testing is enabled automatically through the testing phase and
a test use flag that is set by the testing feature is not needed
because no extra dependencies or actions are required by testing.
This commit was tested in a docker image with dev-util/ebuildtester.
This commit was written, tested, and submitted by Lucas Mitrak.

Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Lucas Mitrak <lucas@lucasmitrak.com>