### PR TITLE
games-util/pokerth-tracker: use default icon path

### DIFF
--- a/games-util/pokerth-tracker/files/pokerth-tracker-desktop_icon_path.patch
+++ b/games-util/pokerth-tracker/files/pokerth-tracker-desktop_icon_path.patch
@@ -1,0 +1,14 @@
+use default desktop icon path instead of custom path set in
+PokerTH_tracker.pro
+Written and tested by Lucas Mitrak.
+
+--- a/PokerTH_tracker.desktop
++++ b/PokerTH_tracker.desktop
+@@ -1,7 +1,7 @@
+ [Desktop Entry]
+ Type=Application
+ Exec=PokerTH_tracker %u
+-Icon=/usr/share/PokerTH_tracker/PokerTH_Tracker.png
++Icon=PokerTH_Tracker
+ Name=PokerTH Tracker
+ Comment=A simple statistics tool to analyse PokerTH logs.

--- a/games-util/pokerth-tracker/pokerth-tracker-0.2.3.2.ebuild
+++ b/games-util/pokerth-tracker/pokerth-tracker-0.2.3.2.ebuild
@@ -29,7 +29,10 @@ dev-qt/qttranslations:5"
 RDEPEND="${DEPEND}
 games-board/pokerth"
 
-PATCHES=( ""${FILESDIR}"/${PN}-disable_find_git.patch" )
+PATCHES=(
+	"${FILESDIR}"/${PN}-disable_find_git.patch
+	"${FILESDIR}"/${PN}-desktop_icon_path.patch
+	)
 
 src_prepare() {
 	sed -e "s/@GIT_COMMIT@/${PV}/g" misc/version.hpp.in > version.hpp

--- a/games-util/pokerth-tracker/pokerth-tracker-9999.ebuild
+++ b/games-util/pokerth-tracker/pokerth-tracker-9999.ebuild
@@ -29,7 +29,10 @@ dev-qt/qttranslations:5"
 RDEPEND="${DEPEND}
 games-board/pokerth"
 
-PATCHES=( ""${FILESDIR}"/${PN}-disable_find_git.patch" )
+PATCHES=(
+	"${FILESDIR}"/${PN}-disable_find_git.patch
+	"${FILESDIR}"/${PN}-desktop_icon_path.patch
+	)
 
 src_prepare() {
 	sed -e "s/@GIT_COMMIT@/${PV}/g" misc/version.hpp.in > version.hpp


### PR DESCRIPTION
Currently,games-util/pokerth-tracker does not have an icon shown in the
taskbar. This is because a custom icon install location is defined in
PokerTH_tracker.pro and PokerTH_tracker.desktop. Since Gentoo uses its
own icon install path, the icon is not found during runtime. The
included patch will change the .desktop file to use a generic icon
path which will allow Gentoo to find the icon correctly. This is done
in a similar way to how the icon is defined in games-board/pokerth [1].
This commit was written, tested, and submitted by Lucas Mitrak.

[1] https://github.com/pokerth/pokerth/blob/stable/pokerth.desktop

Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Lucas Mitrak <lucas@lucasmitrak.com>