### PR TITLE
dev-python/dailysaints: dependency name update

### DIFF
--- a/dev-python/dailysaints/dailysaints-1.0.5.ebuild
+++ b/dev-python/dailysaints/dailysaints-1.0.5.ebuild
@@ -17,7 +17,7 @@ KEYWORDS="~amd64 ~x86"
 DEPEND=""
 RDEPEND="${DEPEND}
 	dev-python/requests
-	dev-python/beautifulsoup
+	dev-python/beautifulsoup4
 "
 BDEPEND=""
 


### PR DESCRIPTION
* Gentoo changed dev-python/beautifulsoup to dev-python/beautifulsoup4

Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Lucas Mitrak <lucas@lucasmitrak.com>