### PR TITLE
media-video/ani-cli: add package

### DIFF
--- a/media-video/ani-cli/ani-cli-9999.ebuild
+++ b/media-video/ani-cli/ani-cli-9999.ebuild
@@ -1,0 +1,33 @@
+# Copyright 2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit git-r3
+
+DESCRIPTION="A cli to browse and watch anime"
+HOMEPAGE="https://github.com/pystardust/ani-cli"
+EGIT_REPO_URI="https://github.com/pystardust/ani-cli.git"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS=""
+
+DEPEND=""
+RDEPEND="${DEPEND}
+	net-misc/curl
+	media-video/mpv
+	media-video/ffmpeg
+"
+BDEPEND=""
+
+src_prepare(){
+	# delete Makefile otherwise it will install during compile phase
+	rm Makefile || die
+	default
+}
+
+src_install(){
+	dobin ani-cli
+	dodoc README.md
+}

--- a/media-video/ani-cli/metadata.xml
+++ b/media-video/ani-cli/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM 'http://www.gentoo.org/dtd/metadata.dtd'>
+<pkgmetadata>
+	<maintainer type="person">
+		<email>lucas@lucasmitrak.com</email>
+		<name>Lucas Mitrak</name>
+	</maintainer>
+</pkgmetadata>


### PR DESCRIPTION
* Add package media-video/ani-cli

A cli to browse and watch anime.
This tool scrapes the site gogoanime.

Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Lucas Mitrak <lucas@lucasmitrak.com>